### PR TITLE
都道府県と人口構成のAPI取得関数を追加

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,19 @@
+import axios from "axios"
+
+const API_KEY = process.env.NEXT_PUBLIC_RESAS_API_KEY;
+const BASE_URL = 'https://opendata.resas-portal.go.jp/api/v1';
+
+export const fetchPrefectures = async () => {
+  const response = await axios.get(`${BASE_URL}/prefectures`, {
+    headers: {'X-API-KEY': API_KEY},
+  });
+  return response.data.result
+}
+
+export const fetchPopulationComposition = async (prefCode: number) => {
+  const response = await axios.get(`${BASE_URL}/population/composition/perYear`, {
+    params: {cityCode: '-', prefCode },
+    headers: {'X-API-KEY': API_KEY},
+  });
+  return response.data.result;
+};


### PR DESCRIPTION
このコミットでは、RESAS APIからデータを取得するための2つの新しいAPI取得関数を導入します。

fetchPrefectures:
RESAS APIから都道府県のリストを取得します。
エンドポイント /prefectures を使用します。
リクエストヘッダーに必要なAPIキーを含めます。

fetchPopulationComposition:
指定された都道府県の人口構成データを取得します。
エンドポイント /population/composition/perYear を使用します。
都道府県を指定するために prefCode をパラメータとして受け取ります。
リクエストヘッダーに必要なAPIキーを含めます。