### PR TITLE
都道府県チェックボックスコンポーネントを追加し、データ取得を実装 &チェックボックスコンポーネントのスタイル

### DIFF
--- a/src/components/PrefectureCheckboxes.module.css
+++ b/src/components/PrefectureCheckboxes.module.css
@@ -1,0 +1,9 @@
+.checkboxContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.checkboxLabel {
+  margin-right:10px;
+}

--- a/src/components/PrefectureCheckboxes.tsx
+++ b/src/components/PrefectureCheckboxes.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import { fetchPrefectures } from "@/utils/api";
+import styles from './PrefectureCheckboxes.module.css';
+
+type Prefecture = {
+  prefCode: number;
+  prefName: string;
+}
+
+const PrefectureCheckboxes: React.FC = () => {
+  const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
+  const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
+  
+  useEffect(() => {
+    const getPrefectures = async () => {
+      const data = await fetchPrefectures();
+      setPrefectures(data);
+    };
+
+    getPrefectures();
+  }, []);
+
+  const handleCheckboxChanges = (prefCode: number) => {
+    setSelectedPrefectures((prev) =>
+    prev.includes(prefCode)
+      ?prev.filter((code) => code !== prefCode)
+    : [...prev, prefCode] )
+  };
+
+  return (
+    <div className={styles.checkboxContainer}>
+      {prefectures.map((pref) => (
+        <label key={pref.prefCode} className={styles.checkboxLabel}>
+          <input
+            type="checkbox"
+            value={pref.prefCode}
+            onChange={() => handleCheckboxChanges(pref.prefCode) }
+          />
+          {pref.prefName}
+        </label>
+      ))}
+
+    </div>
+  )
+};
+
+export default PrefectureCheckboxes;


### PR DESCRIPTION
このコミットでは、都道府県チェックボックスを表示し、データを取得するコンポーネントを追加しました。

PrefectureCheckboxesコンポーネント:
- `useState`と`useEffect`を使用して、都道府県データの取得と状態管理を行います。
- `fetchPrefectures`関数を使用して、RESAS APIから都道府県のリストを取得します。
- ユーザーがチェックボックスをクリックすると、選択された都道府県の状態が更新されます。

主な変更点
- `PrefectureCheckboxes`コンポーネントの追加。
- `fetchPrefectures`関数を用いたデータ取得の実装。
- チェックボックスの状態管理と選択された都道府県のリストを更新するロジックの追加。
- スタイルを適用するために`PrefectureCheckboxes.module.css`ファイルを使用。

このコミットにより、ユーザーは都道府県を選択するインターフェースを利用できるようになり、選択した都道府県のデータを処理することが可能になります。